### PR TITLE
constant of declared with access modifier

### DIFF
--- a/src/Support/Classify.php
+++ b/src/Support/Classify.php
@@ -35,7 +35,7 @@ class Classify
     {
         $value = Dumper::export($value);
 
-        return "\tconst $name = $value;\n";
+        return "\tconst public $name = $value;\n";
     }
 
     /**


### PR DESCRIPTION
As of PHP 7.1.0, class constants may be defined as public, private, or protected. Constants declared without any explicit visibility keyword are defined as public.